### PR TITLE
Fix for incompatibility with NUnit3TestAdapter

### DIFF
--- a/src/NUnitTDNet.Adapter.Tests/BaseDirectoryGuardTests.cs
+++ b/src/NUnitTDNet.Adapter.Tests/BaseDirectoryGuardTests.cs
@@ -1,0 +1,105 @@
+﻿using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace NUnitTDNet.Adapter.Tests
+{
+    [TestClass]
+    public class BaseDirectoryGuardTests
+    {
+        [TestMethod]
+        public void Constructor_MoveFile()
+        {
+            var newContent = "NEW_CONTENT";
+            var dir = Directory.GetCurrentDirectory();
+            var fileName = "file.dll";
+            var file = Path.Combine(dir, fileName);
+            var bakFile = Path.ChangeExtension(file, BaseDirectoryGuard.BackupExtension);
+            File.WriteAllText(file, newContent);
+            File.Delete(bakFile);
+
+            try
+            {
+                var target = new BaseDirectoryGuard(dir, new[] { fileName });
+
+                Assert.IsFalse(File.Exists(file));
+                Assert.AreEqual(newContent, File.ReadAllText(bakFile));
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [TestMethod]
+        public void Constructor_MoveFile_OverwriteBackup()
+        {
+            var newContent = "NEW_CONTENT";
+            var oldContent = "OLD_CONTENT";
+            var dir = Directory.GetCurrentDirectory();
+            var fileName = "file.dll";
+            var file = Path.Combine(dir, fileName);
+            var bakFile = Path.ChangeExtension(file, BaseDirectoryGuard.BackupExtension);
+            File.WriteAllText(file, newContent);
+            File.WriteAllText(bakFile, oldContent);
+
+            try
+            {
+                var target = new BaseDirectoryGuard(dir, new[] { fileName });
+
+                Assert.IsFalse(File.Exists(file));
+                Assert.AreEqual(newContent, File.ReadAllText(bakFile));
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [TestMethod]
+        public void Dispose_RestoreFile()
+        {
+            var newContent = "NEW_CONTENT";
+            var dir = Directory.GetCurrentDirectory();
+            var fileName = "file.dll";
+            var file = Path.Combine(dir, fileName);
+            File.WriteAllText(file, newContent);
+
+            try
+            {
+                var target = new BaseDirectoryGuard(dir, new[] { fileName });
+                target.Dispose();
+
+                Assert.AreEqual(newContent, File.ReadAllText(file));
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [TestMethod]
+        public void Dispose_RestoreFile_RestorePreviousBackup()
+        {
+            var oldContent = "OLD_CONTENT";
+            var dir = Directory.GetCurrentDirectory();
+            var fileName = "file.dll";
+            var file = Path.Combine(dir, fileName);
+            var bakFile = Path.ChangeExtension(file, BaseDirectoryGuard.BackupExtension);
+            File.Delete(file);
+            File.WriteAllText(bakFile, oldContent);
+
+            try
+            {
+                var target = new BaseDirectoryGuard(dir, new[] { fileName });
+                target.Dispose();
+
+                Assert.AreEqual(oldContent, File.ReadAllText(file));
+                Assert.IsFalse(File.Exists(bakFile));
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+    }
+}

--- a/src/NUnitTDNet.Adapter.Tests/NUnitTDNet.Adapter.Tests.csproj
+++ b/src/NUnitTDNet.Adapter.Tests/NUnitTDNet.Adapter.Tests.csproj
@@ -60,6 +60,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="BaseDirectoryGuardTests.cs" />
     <Compile Include="CompilerUtilities.cs" />
     <Compile Include="EngineTestRunnerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/NUnitTDNet.Adapter/BaseDirectoryGuard.cs
+++ b/src/NUnitTDNet.Adapter/BaseDirectoryGuard.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+
+namespace NUnitTDNet.Adapter
+{
+    public class BaseDirectoryGuard : IDisposable
+    {
+        public const string BackupExtension = "tdnet.bak";
+
+        readonly string baseDir;
+        readonly IList<string> fileNames;
+
+        public BaseDirectoryGuard(string baseDir, IList<string> fileNames)
+        {
+            this.baseDir = baseDir;
+            this.fileNames = fileNames;
+
+            foreach (var fileName in fileNames)
+            {
+                var file = Path.Combine(baseDir, fileName);
+                var bakFile = Path.ChangeExtension(file, BackupExtension);
+
+                Move(file, bakFile);
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (var fileName in fileNames)
+            {
+                var file = Path.Combine(baseDir, fileName);
+                var bakFile = Path.ChangeExtension(file, BackupExtension);
+
+                Move(bakFile, file);
+            }
+        }
+
+        static void Move(string sourceFile, string destFile)
+        {
+            if (File.Exists(sourceFile))
+            {
+                if (File.Exists(destFile))
+                {
+                    File.Delete(destFile);
+                }
+
+                File.Move(sourceFile, destFile);
+            }
+        }
+    }
+}

--- a/src/NUnitTDNet.Adapter/BaseDirectoryGuardEngineTestRunner.cs
+++ b/src/NUnitTDNet.Adapter/BaseDirectoryGuardEngineTestRunner.cs
@@ -4,6 +4,10 @@ using TestDriven.Framework;
 
 namespace NUnitTDNet.Adapter
 {
+    // Fix for NUnit3TestAdapter copying `nunit.engine` and `nunit.engine.api`
+    // into the output directory. Move them out of the way while TestDriven.NET
+    // is executing tests. See:
+    // https://github.com/jcansdale/TestDriven.Net-Issues/issues/153
     public class BaseDirectoryGuardEngineTestRunner : ITestRunner
     {
         readonly static string[] dependencies = new[]

--- a/src/NUnitTDNet.Adapter/BaseDirectoryGuardEngineTestRunner.cs
+++ b/src/NUnitTDNet.Adapter/BaseDirectoryGuardEngineTestRunner.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Reflection;
+using TestDriven.Framework;
+
+namespace NUnitTDNet.Adapter
+{
+    public class BaseDirectoryGuardEngineTestRunner : ITestRunner
+    {
+        readonly static string[] dependencies = new[]
+        {
+            "nunit.engine.dll",
+            "nunit.engine.api.dll"
+        };
+
+        public TestRunState RunAssembly(ITestListener testListener, Assembly assembly)
+        {
+            using (CreateBaseDirectoryGuard())
+            {
+                return new EngineTestRunner().RunAssembly(testListener, assembly);
+            }
+        }
+
+        public TestRunState RunMember(ITestListener testListener, Assembly assembly, MemberInfo member)
+        {
+            using (CreateBaseDirectoryGuard())
+            {
+                return new EngineTestRunner().RunMember(testListener, assembly, member);
+            }
+        }
+
+        public TestRunState RunNamespace(ITestListener testListener, Assembly assembly, string ns)
+        {
+            using (CreateBaseDirectoryGuard())
+            {
+                return new EngineTestRunner().RunNamespace(testListener, assembly, ns);
+            }
+        }
+
+        static BaseDirectoryGuard CreateBaseDirectoryGuard()
+        {
+            return new BaseDirectoryGuard(AppDomain.CurrentDomain.BaseDirectory, dependencies);
+        }
+    }
+}

--- a/src/NUnitTDNet.Adapter/nunit.framework.dll.tdnet
+++ b/src/NUnitTDNet.Adapter/nunit.framework.dll.tdnet
@@ -1,7 +1,7 @@
 <TestRunner>
 	<FriendlyName>NUnit {0}.{1}.{2}</FriendlyName>
 	<AssemblyPath>..\..\tools\NUnitTDNet.Adapter.dll</AssemblyPath>
-	<TypeName>NUnitTDNet.Adapter.EngineTestRunner</TypeName>
+	<TypeName>NUnitTDNet.Adapter.BaseDirectoryGuardEngineTestRunner</TypeName>
 	<TargetResolution>Reference</TargetResolution>
 	<ApartmentState>MTA</ApartmentState>
 </TestRunner>


### PR DESCRIPTION
Fix for `NUnit3TestAdapter` copying `nunit.engine` and `nunit.engine.api` into the output directory. Move them out of the way while TestDriven.NET is executing tests.

Fixes https://github.com/jcansdale/TestDriven.Net-Issues/issues/153
